### PR TITLE
Update render.yaml

### DIFF
--- a/render.yaml
+++ b/render.yaml
@@ -2,7 +2,7 @@ services:
   - type: pserv
     name: private-service
     env: node
-    plan: free
+    plan: starter
     repo: https://github.com/render-examples/express-hello-world
     buildCommand: yarn
     startCommand: node app.js


### PR DESCRIPTION
This PR addresses an issue wherein the reverse proxy cannot be deployed to Render because the plan for the associated private service is invalid.

## Description

I changed the value for `plan` from `free` to `starter` for the private service.

## Motivation and Context

The current version of the project cannot be deployed to Render because free plans are not supported for private services.

## How Has This Been Tested?

I tested this by actually deploying the blueprint to Render, and noticed no error.

## Checklist:

- [  ] My change requires a change to the documentation or CHANGELOG.
- [  ] I have updated the documentation/CHANGELOG accordingly.
- [x] I have created a feature (non-master) branch for my PR.
